### PR TITLE
fix: fix the screenshot on hidpi screens

### DIFF
--- a/qml/Storybook/InspectionPanel.qml
+++ b/qml/Storybook/InspectionPanel.qml
@@ -11,8 +11,8 @@ Item {
 
     readonly property ListModel model: ListModel {}
 
-    implicitWidth: image.implicitWidth
-    implicitHeight: image.implicitHeight
+    implicitWidth: sourceItem.width
+    implicitHeight: sourceItem.height
 
     signal clicked(int index)
 
@@ -28,6 +28,9 @@ Item {
 
     Image {
         id: image
+        anchors.fill: parent
+        fillMode: Image.PreserveAspectFit
+        sourceSize: Qt.size(sourceItem.width, sourceItem.height)
     }
 
     function itemsDepthFirst(root) {


### PR DESCRIPTION
- let the Image fill the item, instead of the other way around
- fixes huge screenshots on hidpi screens (where DPR > 1)

<img width="3296" height="2002" alt="image" src="https://github.com/user-attachments/assets/e586face-8a60-48fa-bcda-7d496fd91baa" />
